### PR TITLE
cypress-cli: Pin version to 0.19.4

### DIFF
--- a/cypress-cli/Dockerfile
+++ b/cypress-cli/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:8-slim
 
+ENV CYPRESS_BINARY_VERSION=0.19.4
+
 RUN apt-get -y update \
   && apt-get -y install git libgtk2.0-0 libnotify4 libnotify-dev libgconf-2-4 libnss3 libxss1 xvfb \
   && yarn global add cypress-cli \

--- a/cypress-cli/Dockerfile
+++ b/cypress-cli/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:8-slim
 
+ENV CYPRESS_VERSION=0.19.4
 ENV CYPRESS_BINARY_VERSION=0.19.4
 
 RUN apt-get -y update \


### PR DESCRIPTION
0.20.0 broke our tests
- env CYPRESS_VERSION needed as well
