### PR TITLE
sonar-scanner: Take target branch from GitLab CI variable

### DIFF
--- a/sonar-scanner/bin/preview
+++ b/sonar-scanner/bin/preview
@@ -7,7 +7,7 @@ echo It takes one argument: a comma-separated of directories to check, such as: 
 echo If you want to customize it, run \`$ sonar-scanner \<your-arguments\>\` instead.
 echo
 
-NEW_COMMIT_SHAS=$(git log --pretty=format:%H master..$CI_COMMIT_SHA | tr '\n' ',')
+NEW_COMMIT_SHAS=$(git log --pretty=format:%H ${CI_MERGE_REQUEST_TARGET_BRANCH:-master}..$CI_COMMIT_SHA | tr '\n' ',')
 
 exec sonar-scanner \
     -Dsonar.host.url="$SONARQUBE_URL" \


### PR DESCRIPTION
This variable is to be introduced as part of
https://gitlab.com/gitlab-org/gitlab-ce/issues/23902

Until then, the old behavior is retained by defaulting to master.

Closes https://github.com/kiwicom/dockerfiles/issues/58<Paste>