### PR TITLE
tox: Update to 3.7.0

### DIFF
--- a/tox/Dockerfile
+++ b/tox/Dockerfile
@@ -1,19 +1,18 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 ENV PATH="$PATH:/root/.pyenv/bin:/root/.pyenv/shims"
 
-RUN apk add --no-cache --virtual=.build-deps curl git linux-headers openssl-dev sqlite-dev readline-dev libffi-dev bzip2-dev ncurses-dev sqlite-dev patch && \
-    apk add --no-cache --virtual=.run-deps bash build-base openssl readline libffi libbz2 bzip2 ncurses sqlite sqlite-libs ca-certificates && \
+RUN apk add --no-cache --virtual=.build-deps curl git linux-headers openssl-dev sqlite-dev readline-dev libffi-dev bzip2-dev ncurses-dev sqlite-dev patch xz-dev zlib-dev && \
+    apk add --no-cache --virtual=.run-deps bash build-base openssl readline libffi libbz2 bzip2 ncurses sqlite sqlite-libs zlib xz postgresql-dev ca-certificates && \
     curl --location https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer | bash && \
     pyenv update && \
-    pyenv install 2.7.14 && \
-    pyenv install 3.4.8 && \
-    pyenv install 3.5.5 && \
-    pyenv install 3.6.5 && \
-    pyenv install 3.7.0 && \
-    pyenv global 3.7.0 3.6.5 3.5.5 3.4.8 2.7.14 && \
+    pyenv install 2.7.16 && \
+    pyenv install 3.5.6 && \
+    pyenv install 3.6.8 && \
+    pyenv install 3.7.2 && \
+    pyenv global 3.7.2 3.6.8 3.5.6 2.7.16 && \
     pyenv rehash && \
-    pip install tox==3.5.0 && \
+    pip install tox==3.7.0 && \
     apk del .build-deps && \
     rm -rf /var/cache/apk/* && \
     rm -rf /tmp/* && \


### PR DESCRIPTION
Also:

* Bumped alpine to 3.9
* Dropped support of Python 3.4, as is in limited maintenance and it doesn't support all the latest packages
* Bumped the patch releases for all the python versions
* Added necessary libs for using tox with psycopg2