### PR TITLE
fix(pgbouncer): Name and organise stuff properly

### DIFF
--- a/pgbouncer/Dockerfile
+++ b/pgbouncer/Dockerfile
@@ -1,8 +1,9 @@
+# hadolint ignore=DL3006
 FROM alpine AS base
 
 ENV PGBOUNCER_VERSION=1.12.0
 
-FROM base AS build_stage
+FROM base AS build
 
 # hadolint ignore=DL3018
 RUN apk --update --no-cache add \
@@ -35,7 +36,7 @@ WORKDIR /tmp/pgbouncer
 RUN ./configure --prefix=/usr && \
     make
 
-FROM base
+FROM base AS release
 
 # hadolint ignore=DL3018
 RUN apk --update --no-cache add \
@@ -47,15 +48,16 @@ RUN apk --update --no-cache add \
 WORKDIR /etc/pgbouncer
 WORKDIR /var/log/pgbouncer
 
-RUN addgroup -S postgres && adduser -D -S postgres postgres && \
+RUN addgroup -S postgres && \
+    adduser -D -S postgres postgres && \
     chown -R postgres:root /etc/pgbouncer /var/log/pgbouncer
 
-USER postgres
-
-COPY --from=build_stage --chown=postgres ["/tmp/pgbouncer", "/opt/pgbouncer"]
-COPY --chown=postgres ["entrypoint.sh", "/opt/pgbouncer"]
+COPY --from=build ["/tmp/pgbouncer", "/opt/pgbouncer"]
+COPY ["entrypoint.sh", "/opt/pgbouncer"]
 
 WORKDIR /opt/pgbouncer
+
+USER postgres
 
 ENTRYPOINT ["/opt/pgbouncer/entrypoint.sh"]
 


### PR DESCRIPTION
~When the image is based on `alpine`, the `postgres` user is already created and the command `addgroup/user` fails. When based on `alpine:3.11`, it needs to be created.~

~So this is a fix to create the user only if needed.~

Just organize stuff properly.