### PR TITLE
feat: Add kubeconform image for validating k8s manifests

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        image: ["black", "kubeval", "poetry", "pre-commit", "tox"]
+        image: ["black", "kubeval", "kubeconform", "poetry", "pre-commit", "tox"]
 
     steps:
       - uses: actions/checkout@v2

--- a/kubeconform/Dockerfile
+++ b/kubeconform/Dockerfile
@@ -1,0 +1,35 @@
+FROM alpine:3.13.1@sha256:3747d4eb5e7f0825d54c8e80452f1e245e24bd715972c919d189a62da97af2ae
+
+
+# Checksum from https://github.com/yannh/kubeconform/releases/latest
+ARG KUBECONFORM_VERSION=0.4.2
+# Checksum from https://dl.k8s.io/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256
+ARG KUBECTL_VERSION=1.20.2
+
+RUN apk add --no-cache git~=2.30 && \
+    mkdir -p /tmp/onbuild && \
+    cd /tmp/onbuild && \
+    echo "DOWNLOADING KUBECONFORM v${KUBECONFORM_VERSION}" && \
+    echo "3660e1afb9929c9d524777986d932376f2c6f8950ac6864ee2f6f42e0a42dc9a  -" >kubeconform.sha256 && \
+    wget -qO- "https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" | \
+    tee kubeconform.tar.gz | \
+    sha256sum -c kubeconform.sha256 && \
+    tar xf kubeconform.tar.gz && \
+    chmod +x kubeconform && \
+    mv kubeconform /usr/local/bin/kubeconform && \
+    echo "DOWNLOADING KUBECTL v${KUBECTL_VERSION}" && \
+    echo "2583b1c9fbfc5443a722fb04cf0cc83df18e45880a2cf1f6b52d9f595c5beb88  -" >kubectl.sha256 && \
+    wget -qO- "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl" | \
+    tee /usr/local/bin/kubectl | \
+    sha256sum -c kubectl.sha256 && \
+    chmod +x /usr/local/bin/kubectl && \
+    cd / && \
+    rm -rf /tmp/onbuild
+
+COPY ./analyse /usr/local/bin
+
+CMD ["/usr/local/bin/analyse"]
+
+LABEL name=kubeconform \
+      version.kubeconform=${KUBECONFORM_VERSION} \
+      version.kubectl=${KUBECTL_VERSION}

--- a/kubeconform/Dockerfile
+++ b/kubeconform/Dockerfile
@@ -1,8 +1,8 @@
 FROM alpine:3.13.1@sha256:3747d4eb5e7f0825d54c8e80452f1e245e24bd715972c919d189a62da97af2ae
 
-
 # Checksum from https://github.com/yannh/kubeconform/releases/latest
-ARG KUBECONFORM_VERSION=0.4.2
+ENV version=0.4.2
+ARG KUBECONFORM_VERSION=${version}
 # Checksum from https://dl.k8s.io/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256
 ARG KUBECTL_VERSION=1.20.2
 

--- a/kubeconform/analyse
+++ b/kubeconform/analyse
@@ -1,0 +1,30 @@
+#!/bin/sh
+#
+# This script iterates over all kustomize overlays under specified
+# directory, renders the resulting manifests and performs a kubeconform check on them
+
+set -e
+
+KUBECONFORM_CACHE="${KUBECONFORM_CACHE:-$(mktemp -d)}"
+ANALYSEDIR="${1:-.}"
+
+analyse_overlay() {
+  printf "🧐 %s: \t" "${1}"
+  kubectl kustomize "${1}" | kubeconform --summary -exit-on-error --cache "${KUBECONFORM_CACHE}"
+}
+
+analyse_k8s() {
+  overlays_dir="${1}/overlays"
+  if [ ! -d "${overlays_dir}" ]; then
+    overlays_dir="${1}/*/overlays"
+  fi
+
+  for overlay in "${overlays_dir}"/*; do
+      analyse_overlay "${overlay}"
+  done
+}
+
+mkdir -p "${KUBECONFORM_CACHE}"
+analyse_k8s "$ANALYSEDIR"
+
+exit 0


### PR DESCRIPTION
This commit adds alternative to the kubeval image. The new tool
provides better support and according to the docs is more up to date
with the latest k8s definitions.

Refs:
- https://github.com/yannh/kubeconform
- https://github.com/instrumenta/kubeval/issues/268