### PR TITLE
Bump Poetry version to 1.1.5

### DIFF
--- a/poetry/Dockerfile
+++ b/poetry/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9-alpine
 
-ENV version=1.1.4
+ENV version=1.1.5
 
 RUN apk add --no-cache --virtual .build build-base libffi-dev openssl-dev && \
     pip install --upgrade pip && \


### PR DESCRIPTION
https://github.com/python-poetry/poetry/releases/tag/1.1.5

Fixed an error in the `export` command when no lock file existed and a verbose flag was passed to the command. (python-poetry/poetry#3310)
Fixed an error where the `pyproject.toml` was not reverted when using the `add` command. (python-poetry/poetry#3622)
Fixed errors when using non-HTTPS indices. (python-poetry/poetry#3622)
Fixed errors when handling simple indices redirection. (python-poetry/poetry#3622)
Fixed errors when trying to handle newer wheels by using the latest version of `poetry-core` and `packaging`. (python-poetry/poetry#3677)
Fixed an error when using some versions of `poetry-core` due to an incorrect import . (python-poetry/poetry#3696)
