### PR TITLE
fix(kubeconform): Unquote path expansion

### DIFF
--- a/kubeconform/analyse
+++ b/kubeconform/analyse
@@ -19,7 +19,7 @@ analyse_k8s() {
     overlays_dir="${1}/*/overlays"
   fi
 
-  for overlay in "${overlays_dir}"/*; do
+  for overlay in ${overlays_dir}/*; do
       analyse_overlay "${overlay}"
   done
 }


### PR DESCRIPTION
Asterix is expanded only if is unquoted.

Related to:
- https://pubs.opengroup.org/onlinepubs/009604499/utilities/xcu_chap02.html#tag_02_13_01