### PR TITLE
chore: upgrade kubeconform to 0.4.7

### DIFF
--- a/kubeconform/Dockerfile
+++ b/kubeconform/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.13.1@sha256:3747d4eb5e7f0825d54c8e80452f1e245e24bd715972c919d189a62da97af2ae
 
 # Checksum from https://github.com/yannh/kubeconform/releases/latest
-ENV version=0.4.2
+ENV version=0.4.7
 ARG KUBECONFORM_VERSION=${version}
 # Checksum from https://dl.k8s.io/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256
 ARG KUBECTL_VERSION=1.20.2
@@ -10,7 +10,7 @@ RUN apk add --no-cache git~=2.30 && \
     mkdir -p /tmp/onbuild && \
     cd /tmp/onbuild && \
     echo "DOWNLOADING KUBECONFORM v${KUBECONFORM_VERSION}" && \
-    echo "3660e1afb9929c9d524777986d932376f2c6f8950ac6864ee2f6f42e0a42dc9a  -" >kubeconform.sha256 && \
+    echo "d7a5cb848b783c15119316d716d8a74bf11c9e3ab050f3adf28e0678a6018467  -" >kubeconform.sha256 && \
     wget -qO- "https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" | \
     tee kubeconform.tar.gz | \
     sha256sum -c kubeconform.sha256 && \


### PR DESCRIPTION
I want to use -schema-location default, which is only available
in version 0.4.4 and later.