### PR TITLE
Bump kubeconform version to v0.4.12

### DIFF
--- a/kubeconform/Dockerfile
+++ b/kubeconform/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.9.6-alpine3.14@sha256:3e7e8a57a959c393797f0c90fa7b0fdbf7a40c4a274028e3f28a4f33d4783866
 
 # Checksum from https://github.com/yannh/kubeconform/releases/latest
-ENV version=0.4.8
+ENV version=0.4.12
 ARG KUBECONFORM_VERSION=${version}
 # Checksum from https://dl.k8s.io/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256
 ARG KUBECTL_VERSION=1.21.3
@@ -10,7 +10,7 @@ RUN apk add --no-cache git~=2.32 && \
     mkdir -p /tmp/onbuild && \
     cd /tmp/onbuild && \
     echo "DOWNLOADING KUBECONFORM v${KUBECONFORM_VERSION}" && \
-    echo "4a1be7a6e93ff16e7ad49f291215b3752719cb98a607dc7ab953d781013810b7  -" >kubeconform.sha256 && \
+    echo "c8ebeb665969e42397e4751e03ba66c6ccdf8d914f81fb4190d5bff99f21a5e2  -" >kubeconform.sha256 && \
     wget -qO- "https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" | \
     tee kubeconform.tar.gz | \
     sha256sum -c kubeconform.sha256 && \


### PR DESCRIPTION
Changelogs:

- https://github.com/yannh/kubeconform/releases/tag/v0.4.12
- https://github.com/yannh/kubeconform/releases/tag/v0.4.11
- https://github.com/yannh/kubeconform/releases/tag/v0.4.10
- https://github.com/yannh/kubeconform/releases/tag/v0.4.09
