### PR TITLE
chore: update tox dockerfile

### DIFF
--- a/tox/Dockerfile
+++ b/tox/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM alpine:latest
 
 ENV PATH="$PATH:/root/.pyenv/bin:/root/.pyenv/shims"
 ENV version=3.22.0
@@ -12,7 +12,8 @@ RUN apk add --no-cache --virtual=.build-deps bzip2-dev cargo curl git linux-head
     pyenv install 3.7.9 && \
     pyenv install 3.8.7 && \
     pyenv install 3.9.1 && \
-    pyenv global 3.9.1 3.8.7 3.7.9 3.6.12 3.5.10 && \
+    pyenv install 3.10.0 && \
+    pyenv global 3.10.0 3.9.1 3.8.7 3.7.9 3.6.12 3.5.10 && \
     pyenv rehash && \
     pip install tox==$version && \
     apk del .build-deps && \


### PR DESCRIPTION
Because of the fol

> Follow-up from a [prev request](https://skypicker.slack.com/archives/C7H7958UA/p1649752025024749?thread_ts=1649688054.849829&cid=C7H7958UA), can you pls upgrade [tox](https://github.com/kiwicom/dockerfiles/blob/master/tox/Dockerfile) to include Python 3.10 and make sure the latest docker image is also updated? Currently, latest doesn't even have Py3.9, so we have to [pin](https://gitlab.skypicker.com/platform/security/kiwi-pyiam-django/-/blob/master/.gitlab-ci.yml#L34) a specific version :disappointed: Thx