### PR TITLE
chore!(pre-commit): update to 4.2.0 and revise python support

### DIFF
--- a/pre-commit/Dockerfile
+++ b/pre-commit/Dockerfile
@@ -1,19 +1,18 @@
-FROM python:3.12-slim
+FROM python:3.13-slim
 
 ENV PATH="$PATH:/root/.pyenv/bin:/root/.pyenv/shims"
-ENV version=4.1.0
+ENV version=4.2.0
 
 RUN apt update && \
     apt install -y git golang bash curl build-essential libffi-dev libssl-dev libbz2-dev libncursesw5-dev libgdbm-dev liblzma-dev libsqlite3-dev tk-dev uuid-dev libreadline-dev nodejs npm python3-distutils zlib1g-dev && \
     curl --location https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer | bash && \
     pyenv update && \
-    pyenv install 3.7.17 && \
-    pyenv install 3.8.18 && \
-    pyenv install 3.9.18 && \
-    pyenv install 3.10.13 && \
-    pyenv install 3.11.8 && \
-    pyenv install 3.12.2 && \
-    pyenv global 3.12.2 3.11.8 3.10.13 3.9.18 3.8.18 3.7.17 && \
+    pyenv install 3.9.21 && \
+    pyenv install 3.10.16 && \
+    pyenv install 3.11.11 && \
+    pyenv install 3.12.9 && \
+    pyenv install 3.13.2 && \
+    pyenv global 3.13.2 3.12.9 3.11.11 3.10.16 3.9.21 && \
     pyenv rehash && \
     pip install pre-commit==$version && \
     rm -rf /var/cache/apk/* && \


### PR DESCRIPTION
- update pre-commit version to 4.2.0
- support python 3.13
- BREAKING: drop python 3.7
- BREAKING: drop python 3.8
- update patch versions of all currently supported python releases (3.12, 3.11, 3.10, 3.9)